### PR TITLE
feat: generate php constants for enums

### DIFF
--- a/src/generator/ApiGenerator.php
+++ b/src/generator/ApiGenerator.php
@@ -159,6 +159,11 @@ class ApiGenerator extends Generator
     public $generateMigrations = true;
 
     /**
+     * @var bool whether to generate PHP constants for enum values in models.
+     */
+    public $generateConstantsForEnums = false;
+
+    /**
      * @var string path to create migration files in.
      * Defaults to `@app/migrations`.
      */

--- a/src/generator/default/dbmodel.php
+++ b/src/generator/default/dbmodel.php
@@ -3,6 +3,7 @@
  * @var \cebe\yii2openapi\lib\items\DbModel $model
  * @var string $namespace
  * @var string $relationNamespace
+ * @var bool $generateConstantsForEnums
  **/
 use yii\helpers\Inflector;
 use yii\helpers\VarDumper;
@@ -45,6 +46,14 @@ namespace <?= $namespace ?>;
  */
 abstract class <?= $model->getClassName() ?> extends \yii\db\ActiveRecord
 {
+<?php if ($generateConstantsForEnums && count($model->getEnumAttributes())) : ?>
+<?php foreach ($model->getEnumAttributes() as $attributeName => $attribute) : ?>
+<?php foreach ($attribute->enumValues as $enumValue) : ?>
+    public const <?= strtoupper($attributeName) ?>_<?= strtoupper(Inflector::slug($enumValue, '_', false)) ?> = '<?= $enumValue ?>';
+<?php endforeach; ?>
+
+<?php endforeach; ?>
+<?php endif; ?>
 <?php if (count($model->virtualAttributes())):?>
     protected $virtualAttributes = ['<?=implode("', '", array_map(function ($attr) {
     return $attr->columnName;

--- a/src/lib/Config.php
+++ b/src/lib/Config.php
@@ -135,6 +135,11 @@ class Config extends BaseObject
     public $generateMigrations = true;
 
     /**
+     * @var bool whether to generate PHP constants for enum values in models.
+     */
+    public $generateConstantsForEnums = false;
+
+    /**
      * @var string path to create migration files in.
      * Defaults to `@app/migrations`.
      */

--- a/src/lib/generators/ModelsGenerator.php
+++ b/src/lib/generators/ModelsGenerator.php
@@ -63,6 +63,7 @@ class ModelsGenerator
                             'model' => $model,
                             'namespace' => $this->config->modelNamespace . '\\base',
                             'relationNamespace' => $this->config->modelNamespace,
+                            'generateConstantsForEnums' => $this->config->generateConstantsForEnums,
                         ]
                     )
                 ));


### PR DESCRIPTION
Setting `generateConstantsForEnums = true` in the generator config now generates PHP constants for each enum value in the schema, grouped by column. This feature is `false` by default.

These constants can be useful for referencing enum values across an application, such as in query builder conditions.