### PR TITLE
feat: override action templates

### DIFF
--- a/src/generator/ApiGenerator.php
+++ b/src/generator/ApiGenerator.php
@@ -176,6 +176,17 @@ class ApiGenerator extends Generator
     public $migrationNamespace;
 
     /**
+     * @var string Class to use for `ActionTemplates`.
+     *
+     * This class contains methods for generating action templates, and can be
+     * overridden to customise these templates.
+     *
+     * Overridden action templates classes must extend
+     * `\cebe\yii2openapi\lib\items\ActionTemplates`.
+     */
+    public $actionTemplatesClass = '\cebe\yii2openapi\lib\items\ActionTemplates';
+
+    /**
      * @var OpenApi
      */
     private $_openApiWithoutRef;

--- a/src/lib/Config.php
+++ b/src/lib/Config.php
@@ -151,6 +151,17 @@ class Config extends BaseObject
      */
     public $migrationNamespace;
 
+    /**
+     * @var string Class to use for `ActionTemplates`.
+     *
+     * This class contains methods for generating action templates, and can be
+     * overridden to customise these templates.
+     *
+     * Overridden action templates classes must extend
+     * `\cebe\yii2openapi\lib\items\ActionTemplates`.
+     */
+    public $actionTemplatesClass = '\cebe\yii2openapi\lib\items\ActionTemplates';
+
     private $fileRenderer;
 
     /**

--- a/src/lib/generators/RestActionGenerator.php
+++ b/src/lib/generators/RestActionGenerator.php
@@ -11,6 +11,7 @@ use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Reference;
 use cebe\yii2openapi\lib\Config;
+use cebe\yii2openapi\lib\items\ActionTemplates;
 use cebe\yii2openapi\lib\items\RestAction;
 use cebe\yii2openapi\lib\items\RouteData;
 use cebe\yii2openapi\lib\openapi\ResponseSchema;
@@ -109,6 +110,10 @@ class RestActionGenerator
         } else {
             $controllerId = $routeData->controller;
         }
+
+        /** @var ActionTemplates */
+        $actionTemplates = Yii::createObject($this->config->actionTemplatesClass);
+
         return Yii::createObject(RestAction::class, [
             [
                 'id' => trim("$actionType{$routeData->action}", '-'),
@@ -124,7 +129,8 @@ class RestActionGenerator
                     : null,
                 'responseWrapper' => $responseWrapper,
                 'prefix' => $routeData->getPrefix(),
-                'prefixSettings' => $routeData->getPrefixSettings()
+                'prefixSettings' => $routeData->getPrefixSettings(),
+                'actionTemplates' => $actionTemplates,
             ],
         ]);
     }

--- a/src/lib/items/RestAction.php
+++ b/src/lib/items/RestAction.php
@@ -7,6 +7,7 @@
 
 namespace cebe\yii2openapi\lib\items;
 
+use Yii;
 use yii\base\BaseObject;
 use yii\helpers\Inflector;
 use yii\helpers\StringHelper;
@@ -68,6 +69,23 @@ final class RestAction extends BaseObject
      */
     public $responseWrapper;
 
+    /**
+     * @var ActionTemplates
+     */
+    public $actionTemplates;
+
+    /**
+     * @inheritdoc
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        if (!$this->actionTemplates) {
+            $this->actionTemplates = Yii::createObject(ActionTemplates::class);
+        }
+    }
+
     public function getRoute():string
     {
         if ($this->prefix && !empty($this->prefixSettings)) {
@@ -121,13 +139,13 @@ final class RestAction extends BaseObject
 
     public function hasTemplate():bool
     {
-        return ActionTemplates::hasTemplate($this->id);
+        return $this->actionTemplates::hasTemplate($this->id);
     }
 
     public function getTemplate():?string
     {
         //@TODO: Model scenarios for create/update actions
-        $template = ActionTemplates::getTemplate($this->id);
+        $template = $this->actionTemplates::getTemplate($this->id);
         if (!$template) {
             return null;
         }
@@ -185,7 +203,7 @@ PHP;
             return false; //Default template action used
         }
 
-        if (!ActionTemplates::hasImplementation($this->id)) {
+        if (!$this->actionTemplates::hasImplementation($this->id)) {
             return true;
         }
 
@@ -194,7 +212,7 @@ PHP;
 
     public function getImplementation():?string
     {
-        $template = ActionTemplates::getTemplate($this->id);
+        $template = $this->actionTemplates::getTemplate($this->id);
         return strtr(
             $template['implementation'],
             [
@@ -212,6 +230,6 @@ PHP;
 
     public function shouldUseCustomFindModel():bool
     {
-        return ActionTemplates::hasImplementation($this->id) && !$this->hasStandardId();
+        return $this->actionTemplates::hasImplementation($this->id) && !$this->hasStandardId();
     }
 }


### PR DESCRIPTION
Allows overridding `ActionTemplates`, which is used to generate REST actions. This lets developers customise the generated controller actions.