### PR TITLE
feat: add config to prevent dropping specified columns

### DIFF
--- a/src/generator/ApiGenerator.php
+++ b/src/generator/ApiGenerator.php
@@ -134,6 +134,16 @@ class ApiGenerator extends Generator
     public $excludeModels = [];
 
     /**
+     * @var array List of column names which are never dropped in database
+     * migrations, even if they aren't included in the OpenAPI definition.
+     *
+     * This is useful for "hidden" properties; columns that you want in the
+     * database and your extended models, but you don't want to have them
+     * appear in your OpenAPI definition.
+     */
+    public $neverDropColumns = [];
+
+    /**
      * @var array Map for custom controller names not based on model name for exclusive cases
      * @example
      *  'controllerModelMap' => [

--- a/src/lib/Config.php
+++ b/src/lib/Config.php
@@ -110,6 +110,16 @@ class Config extends BaseObject
     public $excludeModels = [];
 
     /**
+     * @var array List of column names which are never dropped in database
+     * migrations, even if they aren't included in the OpenAPI definition.
+     *
+     * This is useful for "hidden" properties; columns that you want in the
+     * database and your extended models, but you don't want to have them
+     * appear in your OpenAPI definition.
+     */
+    public $neverDropColumns = [];
+
+    /**
      * @var array Map for custom controller names not based on model name for exclusive cases
      * @example
      *  'controllerModelMap' => [

--- a/src/lib/generators/MigrationsGenerator.php
+++ b/src/lib/generators/MigrationsGenerator.php
@@ -135,9 +135,9 @@ class MigrationsGenerator
     protected function createBuilder(DbModel $model):BaseMigrationBuilder
     {
         if ($this->db->getDriverName() === 'pgsql') {
-            return Yii::createObject(PostgresMigrationBuilder::class, [$this->db, $model]);
+            return Yii::createObject(PostgresMigrationBuilder::class, [$this->db, $model, $this->config]);
         }
-        return Yii::createObject(MysqlMigrationBuilder::class, [$this->db, $model]);
+        return Yii::createObject(MysqlMigrationBuilder::class, [$this->db, $model, $this->config]);
     }
 
     /**


### PR DESCRIPTION
Adds the config option `neverDropColumns` which specifies a list of column names, and their associated model names, to prevent from being dropped when generating database migrations.

The motivation for this is "hidden" properties. If you're using one OpenAPI definition file to generate a backend API and a frontend SDK, there may be some properties you want on the backend API (such as user management/security columns, e.g. `auth_key`) that you don't want to appear on the frontend SDK. With no clear way to do this in the OpenAPI definition, the solution here is to simply not include the properties in the definition and implement them manually in the backend API. When the API code generator sees that the columns have been removed from the definition, the new `neverDropColumns` config option is what prevents them being dropped.