### PR TITLE
feat: add x-fk-nullable extension property

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ Allow to set foreign key constraint in migrations for ON UPDATE event of row in 
 
 Use on a path. This extension, when set to `true`, forces the generator to use the `operationId` as the action ID for that path.
 
+### `x-fk-nullable`
+
+Some OpenAPI generators don't generate inline schemas correctly if additional properties are specified.
+
+You can set `x-fk-nullable` to tell the Yii generator to make the foreign key column nullable, working around the limitation set by other generators.
+
 ## Many-to-Many relation definition
 
 There are two ways for define many-to-many relations:

--- a/src/lib/openapi/PropertySchema.php
+++ b/src/lib/openapi/PropertySchema.php
@@ -89,6 +89,10 @@ class PropertySchema
         $this->isPk = $name === $schema->getPkName();
         $this->isNullable = $property->nullable ?? false;
 
+        if (!empty($property->{'x-fk-nullable'})) {
+            $this->isNullable = $property->{'x-fk-nullable'};
+        }
+
         $onUpdate = $onDelete = $reference = null;
 
         foreach ($property->allOf ?? [] as $element) {
@@ -105,6 +109,16 @@ class PropertySchema
                 $reference = $element;
             }
         }
+
+        if ($onUpdate === null || $onDelete === null) {
+            if (!empty($property->{CustomSpecAttr::FK_ON_UPDATE})) {
+                $onUpdate = $property->{CustomSpecAttr::FK_ON_UPDATE};
+            }
+            if (!empty($property->{CustomSpecAttr::FK_ON_DELETE})) {
+                $onDelete = $property->{CustomSpecAttr::FK_ON_DELETE};
+            }
+        }
+
         if (
             ($onUpdate !== null || $onDelete !== null) &&
             ($reference instanceof Reference)


### PR DESCRIPTION
Some OpenAPI generators (e.g. `typescript-fetch`) generate multiple identical interfaces for what should be "inline schemas", that is, a schema that references only one other using `allOf`, when the property specifies additional properties like `nullable`.

Instead, the `x-fk-nullable` extension can be used to work around this limitation. It works exactly the same as `nullable` when generating foreign key columns, but allows other code generators to work properly.