### PR TITLE
fix: migration name date conflict

### DIFF
--- a/src/lib/items/MigrationModel.php
+++ b/src/lib/items/MigrationModel.php
@@ -107,10 +107,10 @@ class MigrationModel extends BaseObject
     public function makeClassNameByTime(int $index, ?string $nameSpace = null, ?string $date = null):string
     {
         if ($nameSpace) {
-            $m = sprintf('%s%04d', ($date ?: date('ymdH')), $index);
+            $m = sprintf('%s_%04d', ($date ?: date('ymdHis')), $index);
             $this->fileClassName = "M{$m}" . Inflector::id2camel($this->fileName, '_');
         } else {
-            $m = sprintf('%s%04d', ($date ?: date('ymd_H')), $index);
+            $m = sprintf('%s_%04d', ($date ?: date('ymd_His')), $index);
             $this->fileClassName = "m{$m}_" . $this->fileName;
         }
         return $this->fileClassName;


### PR DESCRIPTION
When multiple migrations are generated separately (that is, by multiple operations) in the same hour, the file names become unordered. This causes migrations that depend on previous migrations to be generated out of order, which has been causing migration failures.

This commit prevents this behaviour by adding the minutes and seconds to the migration file name. The migration names are then ordered more precisely.