### PR TITLE
feat: prevent foreign keys being dropped by configuration

### DIFF
--- a/src/lib/migrations/BaseMigrationBuilder.php
+++ b/src/lib/migrations/BaseMigrationBuilder.php
@@ -376,6 +376,21 @@ abstract class BaseMigrationBuilder
             $fkCol = $relation[$refCol];
             $existedRelations[$fkName] = ['refTable' => $refTable, 'refCol' => $refCol, 'fkCol' => $fkCol];
         }
+
+        /**
+         * Filter out foreign keys that we want to prevent dropping, as
+         * defined by column names in `ApiGenerator::$neverDropColumns`.
+         */
+        if (array_key_exists($this->model->name, $this->config->neverDropColumns)) {
+            $existedRelations = array_filter(
+                $existedRelations,
+                fn (array $fkDefinition): bool => !in_array(
+                    $fkDefinition['refCol'],
+                    $this->config->neverDropColumns[$this->model->name]
+                )
+            );
+        }
+
         foreach ($this->model->getHasOneRelations() as $relation) {
             $fkCol = $relation->getColumnName();
             $refCol = $relation->getForeignName();


### PR DESCRIPTION
The code generator now prevents dropping foreign keys of columns that are specified in configuration as to "never drop", which brings this in line with the columns themselves and indexes.